### PR TITLE
Add histos

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -55,7 +55,7 @@ backCollimatorDet = 1
 
 [Output]
 mode = detailed
-nbinsE = 200
+binWidthE = 0.5
 nbinsProf = 200
 fileName = TestTest123
 

--- a/config.ini
+++ b/config.ini
@@ -55,6 +55,8 @@ backCollimatorDet = 1
 
 [Output]
 mode = detailed
+nbinsE = 200
+nbinsProf = 200
 fileName = TestTest123
 
 [GPS]

--- a/include/AnaConfigManager.hh
+++ b/include/AnaConfigManager.hh
@@ -17,6 +17,7 @@ class AnaConfigManager {
     //member functions  
     void SetUp(const G4Run* aRun, G4String outFileName);
     void BookNtuples();
+    void BookHistos();
     void Save() const;
 
     void FillBaseNtuple_summary(int tupleID,
@@ -31,6 +32,7 @@ class AnaConfigManager {
     void FillCaloCrystNtuple_summary(int tupleID,
                                     const std::vector<double> Edep,
                                     const std::vector<double> Tlength) const;
+    void FillHistos(int histoID, G4Step* step) const;
     void SetupMetadataTTree();
 
     //getter methods 
@@ -42,6 +44,9 @@ class AnaConfigManager {
     }
     const std::vector<TreeInfo>& GetTreesInfo() const {
         return fTreesInfo;
+    }
+    const std::vector<HistoInfo>& GetHistoInfo() const {
+        return fHistoInfo;
     }
     std::map<std::string, int>& GetNtupleNameToIdMap(){
     return fNtupleNameToIdMap;
@@ -63,7 +68,7 @@ class AnaConfigManager {
     const int fShowerDevStat;
     const std::vector<TreeInfo> fTreesInfo; // tree info is structure with name, title and id
     std::map<std::string, int> fNtupleNameToIdMap; // need this for defining sensitive volumes in the subdetector classes
-
+    const std::vector<HistoInfo>fHistoInfo;
 }; 
 
 

--- a/include/ConfigReader.hh
+++ b/include/ConfigReader.hh
@@ -22,6 +22,13 @@ struct TreeInfo {
         : name(n), title(t), id(i) {}
 };
 
+struct HistoInfo{
+    std::string title; 
+    int id;
+    HistoInfo(const std::string& t, int i)
+    : title(t), id(i) {}
+};
+
 class ConfigReader {
 public:
     ConfigReader(const std::string& configFile);
@@ -38,6 +45,7 @@ public:
     //methods for reading tree and branch configurations 
     std::vector<TreeInfo> ReadTreesInfo() const;
     std::vector<BranchInfo> GetBranchesInfo(const std::string& treeName) const;
+    std::vector<HistoInfo> ReadHistoInfo() const;
 
 private:
     std::string fConfigFile;

--- a/src/AnaConfigManager.cc
+++ b/src/AnaConfigManager.cc
@@ -69,7 +69,7 @@ void AnaConfigManager::BookNtuples() {
 
 void AnaConfigManager::BookHistos(){
     // Get the number of bins for both types of histograms 
-    int nbinsE = fConfig.GetConfigValueAsInt("Output","nbinsE");
+    double binWidthE = fConfig.GetConfigValueAsDouble("Output","binWidthE");
     int nbinsProf = fConfig.GetConfigValueAsInt("Output","nbinsProf");
 
     // Get the maximum energy of the bremsspec
@@ -110,13 +110,16 @@ void AnaConfigManager::BookHistos(){
         Emax = 100.0;
     }
 
+    int nbinsE = int(Emax/binWidthE);
+    G4cout << "NUMBER OF BINS  ="<< nbinsE <<"......................." << G4endl;
+
     // now get the actual booking done for every sd with histo
     G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
     for (const auto& histoInfo : fHistoInfo) {
         
         // Histo with the particle total energy spectrum 
         analysisManager->CreateH1(histoInfo.title,
-        "E_tot_spec", nbinsE, 0. , Emax);
+        "E_tot_spec", nbinsE, 0. , nbinsE*binWidthE);
 
         // Histo with the beam profile 
         analysisManager->CreateH2(histoInfo.title, "Beam Profile", 

--- a/src/AnaConfigManager.cc
+++ b/src/AnaConfigManager.cc
@@ -5,12 +5,14 @@
 #include "G4Step.hh"
 #include "G4RunManager.hh"
 #include "G4AnalysisManager.hh"
+#include "G4SystemOfUnits.hh"
 
 AnaConfigManager::AnaConfigManager(const ConfigReader& config)
   : fConfig(config),
     fOutputMode(config.ReadOutputMode()),
     fOutputFileName(config.ReadOutputFileName()),
     fTreesInfo(config.ReadTreesInfo()),
+    fHistoInfo(config.ReadHistoInfo()),
     fEinLim(config.ReadEinLim()),
     fShowerDevStat(config.ReadShowerDevStat()) {
     
@@ -43,6 +45,9 @@ void AnaConfigManager::SetUp( const G4Run* aRun,
     // Book the ntuples (GEANT4 lingo for Ttrees)
     BookNtuples();
 
+    // Create the histograms 
+    BookHistos();
+
 };
 
 void AnaConfigManager::BookNtuples() {
@@ -59,6 +64,63 @@ void AnaConfigManager::BookNtuples() {
             }
         }
         analysisManager->FinishNtuple();
+    }
+};
+
+void AnaConfigManager::BookHistos(){
+    // Get the number of bins for both types of histograms 
+    int nbinsE = fConfig.GetConfigValueAsInt("Output","nbinsE");
+    int nbinsProf = fConfig.GetConfigValueAsInt("Output","nbinsProf");
+
+    // Get the maximum energy of the bremsspec
+    std::string eneType = fConfig.GetConfigValue("GPS","eneType");
+
+    double Emax;
+    if (eneType == "Gauss"){
+        Emax = fConfig.GetConfigValueAsDouble("GPS","energy");
+    }else if(eneType == "User"){
+        // get the highest histo value
+        std::string histFilePath = fConfig.GetConfigValue("GPS", "histName");
+        // Open the text file
+        std::ifstream histFile(histFilePath);
+        if (!histFile.is_open()) {
+            std::cerr << "Error: Cannot open the file: " << histFilePath << std::endl;
+            return;
+        }
+
+        // Read the last line to get the maximum energy value
+        std::string line;
+        std::string lastLine;
+        while (std::getline(histFile, line)) {
+            if (!line.empty()) {
+                lastLine = line;
+            }
+        }
+
+        histFile.close();
+
+        // Parse the last line to get the maximum energy value
+        std::istringstream iss(lastLine);
+        std::string dummy;
+        double energy;
+        if (iss >> dummy >> dummy >> energy) {
+            Emax = energy;
+        }
+    }else{
+        Emax = 100.0;
+    }
+
+    // now get the actual booking done for every sd with histo
+    G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
+    for (const auto& histoInfo : fHistoInfo) {
+        
+        // Histo with the particle total energy spectrum 
+        analysisManager->CreateH1(histoInfo.title,
+        "E_tot_spec", nbinsE, 0. , Emax);
+
+        // Histo with the beam profile 
+        analysisManager->CreateH2(histoInfo.title, "Beam Profile", 
+        nbinsProf, -60.0*mm, 60.0*mm, nbinsProf, -60.0*mm, 60.0*mm);
     }
 };
 
@@ -195,7 +257,16 @@ void AnaConfigManager::FillCaloCrystNtuple_summary(int tupleID,
         analysisManager->FillNtupleDColumn(tupleID, 9+i, Edep_ct[i]);
     }
     analysisManager->AddNtupleRow(tupleID);
-}
+};
+
+
+void AnaConfigManager::FillHistos(int ID, G4Step* step)const{
+    G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
+    auto PSP = step->GetPostStepPoint();
+    auto ene = PSP->GetTotalEnergy()/CLHEP::MeV;
+    analysisManager->FillH1(ID,ene);
+    analysisManager->FillH2(ID, PSP->GetPosition().x(),PSP->GetPosition().y(),ene);
+};
 
 void AnaConfigManager::SetupMetadataTTree() {
     G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();

--- a/src/BaseSensitiveDetector.cc
+++ b/src/BaseSensitiveDetector.cc
@@ -18,6 +18,9 @@ BaseSensitiveDetector::BaseSensitiveDetector(const G4String& name, const std::st
 BaseSensitiveDetector::~BaseSensitiveDetector() {}
 
 G4bool BaseSensitiveDetector::ProcessHits(G4Step* step, G4TouchableHistory* history) {
+    // No matter what the output format, always fill the histograms !  
+    fAnaConfigManager.FillHistos(fTupleID,step);
+    
     // Common data processing logic, using layerIdentifier for differentiation
     if (step->GetPostStepPoint()->GetMomentumDirection().z() > 0){
         if (fOutputMode == "detailed") {

--- a/src/CaloFrontSensitiveDetector.cc
+++ b/src/CaloFrontSensitiveDetector.cc
@@ -23,6 +23,8 @@ CaloFrontSensitiveDetector::CaloFrontSensitiveDetector(const G4String& name, con
 CaloFrontSensitiveDetector::~CaloFrontSensitiveDetector() {}
 
 G4bool CaloFrontSensitiveDetector::ProcessHits(G4Step* step, G4TouchableHistory* history) {
+    // No matter what the output format, always fill the histograms !  
+    fAnaConfigManager.FillHistos(fTupleID,step);
 
     // Add some 
     //G4cout << "ProcessHits called for volume: " << step->GetPreStepPoint()->GetPhysicalVolume()->GetName() << G4endl;

--- a/src/ConfigReader.cc
+++ b/src/ConfigReader.cc
@@ -170,6 +170,46 @@ std::vector<TreeInfo> ConfigReader::ReadTreesInfo() const {
     return trees;
 }
 
+std::vector<HistoInfo> ConfigReader::ReadHistoInfo() const {
+    // Logic to read histo configurations from fConfigValues
+
+    // declare the tree vector 
+    std::vector<HistoInfo> histos;
+
+    // check all the geometry and detector states 
+    // for now just Solenoid 
+    G4int ICdet, bCDet, CFdet, CCdet, CBdet;
+
+    G4cout << "GetTreesInfo() is called" << G4endl;
+    G4int solenoidStatus = GetConfigValueAsInt("Solenoid","solenoidStatus");
+    if (solenoidStatus){
+        ICdet = GetConfigValueAsInt("Solenoid","inFrontCore");
+        if (ICdet>0){
+            histos.push_back(HistoInfo("inFrontCore", 0));
+        }
+        bCDet = GetConfigValueAsInt("Solenoid","behindCore");
+        if (bCDet){
+            histos.push_back(HistoInfo("behindCore",ICdet));
+        }
+    }
+    G4int caloStatus = GetConfigValueAsInt("Calorimeter","calorimeterStatus");
+    if(caloStatus){
+        CFdet = GetConfigValueAsInt("Calorimeter","frontDetector");
+        if(CFdet){
+            G4int histID = solenoidStatus*(ICdet+bCDet);
+            histos.push_back(HistoInfo("inFrontCalo", histID));
+        }
+        // CBdet = GetConfigValueAsInt("Calorimeter","backDetector");
+        // if(CBdet){
+        //     G4int histID = solenoidStatus*(ICdet+bCDet)+CFdet;
+        //     histos.push_back(HistoInfo("behindCalo", histID));
+        // }
+    }
+    G4cout << "histos size: " << histos.size() << G4endl;
+    return histos;
+}
+
+
 std::vector<BranchInfo> ConfigReader::GetBranchesInfo(const std::string& treeName) const {
     std::vector<BranchInfo> branches;
     


### PR DESCRIPTION
No matter the output type, 2 histograms per ideal detector volume are saved. A 1d one for the energy spectrum and a 2d one for the beam profile (weighted with energy)